### PR TITLE
Cwd flag needs to be first argument

### DIFF
--- a/plugins/bulletin-board/README.md
+++ b/plugins/bulletin-board/README.md
@@ -4,7 +4,7 @@ Add the frontend plugin package:
 
 ```bash
 # From your Backstage root directory
-yarn add --cwd packages/app backstage-plugin-bulletin-board
+yarn --cwd packages/app add backstage-plugin-bulletin-board
 ```
 
 Modify your app routes in `packages/app/src/App.tsx`:


### PR DESCRIPTION
Yarn throws an error if `--cwd` is not in the first position